### PR TITLE
BTC-e closed, relaunched as WEX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-[![Build Status](https://travis-ci.org/onuryilmaz/go-btce.svg?branch=master)](https://travis-ci.org/onuryilmaz/go-btce)
-[![Go Report Card](https://goreportcard.com/badge/github.com/onuryilmaz/go-btce)](https://goreportcard.com/report/github.com/onuryilmaz/go-btce)
-[![GoDoc](https://godoc.org/github.com/onuryilmaz/go-btce?status.svg)](https://godoc.org/github.com/onuryilmaz/go-btce)
-[![Coverage Status](https://coveralls.io/repos/github/onuryilmaz/go-btce/badge.svg?branch=master)](https://coveralls.io/github/onuryilmaz/go-btce?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/KopfKrieg/go-wex)](https://goreportcard.com/report/github.com/KopfKrieg/go-wex)
+[![GoDoc](https://godoc.org/github.com/KopfKrieg/go-wex?status.svg)](https://godoc.org/github.com/KopfKrieg/go-wex)
 
-## BTC-E API Go Client
-Native Go client for interacting with [BTC-E](https://btc-e.com/) [Public API v3](https://btc-e.com/api/3/docs) and [Trading API](https://btc-e.com/tapi/docs).
+## WEX (former BTC-E) API Go Client
+Native Go client for interacting with [WEX](https://wex.nz/) [Public API v3](https://wex.nz/api/3/docs) and [Trading API](https://wex.nz/tapi/docs).
 
 ### Usage
 
@@ -13,12 +11,12 @@ package main
 
 import (
 	"fmt"
-	btc "github.com/onuryilmaz/go-btce"
+	wex "github.com/KopfKrieg/go-wex"
 )
 
 func main() {
 
-	api := btc.API{}
+	api := wex.API{}
 
 	ticker, err := api.Public.Ticker([]string{"btc_usd"})
 	if err == nil {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/KopfKrieg/go-wex)](https://goreportcard.com/report/github.com/KopfKrieg/go-wex)
-[![GoDoc](https://godoc.org/github.com/KopfKrieg/go-wex?status.svg)](https://godoc.org/github.com/KopfKrieg/go-wex)
+[![Build Status](https://travis-ci.org/onuryilmaz/go-wex.svg?branch=master)](https://travis-ci.org/onuryilmaz/go-wex)
+[![Go Report Card](https://goreportcard.com/badge/github.com/onuryilmaz/go-wex)](https://goreportcard.com/report/github.com/onuryilmaz/go-wex)
+[![GoDoc](https://godoc.org/github.com/onuryilmaz/go-wex?status.svg)](https://godoc.org/github.com/onuryilmaz/go-wex)
+[![Coverage Status](https://coveralls.io/repos/github/onuryilmaz/go-wex/badge.svg?branch=master)](https://coveralls.io/github/onuryilmaz/go-wex?branch=master)
 
 ## WEX (former BTC-E) API Go Client
 Native Go client for interacting with [WEX](https://wex.nz/) [Public API v3](https://wex.nz/api/3/docs) and [Trading API](https://wex.nz/tapi/docs).
@@ -11,7 +13,7 @@ package main
 
 import (
 	"fmt"
-	wex "github.com/KopfKrieg/go-wex"
+	wex "github.com/onuryilmaz/go-wex"
 )
 
 func main() {

--- a/public.go
+++ b/public.go
@@ -1,4 +1,4 @@
-package btce
+package wex
 
 import (
 	"encoding/json"
@@ -9,7 +9,7 @@ import (
 // PublicAPI provides access to such information as tickers of currency pairs, active orders on different pairs, the latest trades for each pair etc.
 type PublicAPI struct{}
 
-const apiURL = "https://btc-e.com/api/3/"
+const apiURL = "https://wex.nz/api/3/"
 
 // Info provides all the information about currently active pairs, such as the maximum number of digits after the decimal point, the minimum price, the maximum price, the minimum transaction size, whether the pair is hidden, the commission for each pair.
 func (api *PublicAPI) Info() (Info, error) {

--- a/public_test.go
+++ b/public_test.go
@@ -1,4 +1,4 @@
-package btce
+package wex
 
 import (
 	. "github.com/smartystreets/goconvey/convey"

--- a/structs.go
+++ b/structs.go
@@ -1,4 +1,4 @@
-package btce
+package wex
 
 import (
 	"encoding/json"

--- a/trade.go
+++ b/trade.go
@@ -1,4 +1,4 @@
-package btce
+package wex
 
 import (
 	"bytes"
@@ -25,7 +25,7 @@ type TradeAPI struct {
 	lastNonce  int64
 }
 
-const tradeURL = "https://btc-e.com/tapi"
+const tradeURL = "https://wex.nz/tapi"
 
 // Auth provides API key and secret setting for Trade API
 func (tapi *TradeAPI) Auth(key string, secret string) {

--- a/trade_test.go
+++ b/trade_test.go
@@ -1,4 +1,4 @@
-package btce
+package wex
 
 import (
 	"os"

--- a/trade_test.go
+++ b/trade_test.go
@@ -175,7 +175,7 @@ func TestWithdrawCoin(t *testing.T) {
 				So(err, ShouldResemble, TradeError{msg: "api key dont have withdraw permission"})
 			})
 		} else {
-			Convey("If no error is returned, withdraw reponse should be returned", func() {
+			Convey("If no error is returned, withdraw response should be returned", func() {
 				So(response.TransactionID, ShouldBeGreaterThan, 0)
 				So(response.AmountSent, ShouldBeGreaterThanOrEqualTo, 0)
 			})
@@ -196,7 +196,7 @@ func TestCreateCoupon(t *testing.T) {
 				So(err, ShouldResemble, TradeError{msg: "api key dont have coupon permission"})
 			})
 		} else {
-			Convey("If no error is returned, withdraw reponse should be returned", func() {
+			Convey("If no error is returned, withdraw response should be returned", func() {
 				So(response.Coupon, ShouldNotBeBlank)
 				So(response.TransactionID, ShouldBeGreaterThan, 0)
 			})
@@ -217,7 +217,7 @@ func TestRedeemCoupon(t *testing.T) {
 				So(err, ShouldResemble, TradeError{msg: "api key dont have coupon permission"})
 			})
 		} else {
-			Convey("If no error is returned, withdraw reponse should be returned", func() {
+			Convey("If no error is returned, withdraw response should be returned", func() {
 				So(response.CouponCurrency, ShouldNotBeBlank)
 				So(response.TransactionID, ShouldBeGreaterThan, 0)
 			})

--- a/wex.go
+++ b/wex.go
@@ -6,7 +6,7 @@
 //
 // 	import (
 //		"fmt"
-//		wex "github.com/KopfKrieg/go-wex"
+//		wex "github.com/onuryilmaz/go-wex"
 // 	)
 //
 // 	func main() {

--- a/wex.go
+++ b/wex.go
@@ -1,4 +1,4 @@
-// Package btce provides native Go client for interacting with BTC-E Public API v3 and Trading API.
+// Package wex provides native Go client for interacting with WEX (former BTC-E) Public API v3 and Trading API.
 //
 // Example usage:
 //
@@ -6,12 +6,12 @@
 //
 // 	import (
 //		"fmt"
-//		btc "github.com/onuryilmaz/go-btce"
+//		wex "github.com/KopfKrieg/go-wex"
 // 	)
 //
 // 	func main() {
 //
-//		api := btc.API{}
+//		api := wex.API{}
 //
 //		ticker, err := api.Public.Ticker([]string{"btc_usd"})
 //		if err == nil {
@@ -24,7 +24,7 @@
 //			fmt.Printf("BTC amount: %.3f \n", info.Funds["btc"])
 //		}
 // 	}
-package btce
+package wex
 
 // API allows to use public and trade APIs of BTC-E
 type API struct {

--- a/wex_test.go
+++ b/wex_test.go
@@ -1,22 +1,22 @@
-package btce
+package wex
 
 import (
 	. "github.com/smartystreets/goconvey/convey"
 	"testing"
 )
 
-var btce = API{}
+var wex = API{}
 
-func TestBTCE(t *testing.T) {
+func TestWEX(t *testing.T) {
 
-	Convey("BTCE instance created", t, func() {
+	Convey("WEX instance created", t, func() {
 
 		Convey("Public API should be available", func() {
-			So(btce.Public, ShouldNotBeNil)
+			So(wex.Public, ShouldNotBeNil)
 		})
 
 		Convey("Trade API should be available", func() {
-			So(btce.Trade, ShouldNotBeNil)
+			So(wex.Trade, ShouldNotBeNil)
 		})
 	})
 }


### PR DESCRIPTION
As you might know BTC-e closed (or better: got closed), and relaunched as [WEX](https://wex.nz). I changed all lines in your code referring to btce to wex, the API itself stayed the same. So, if you're still maintaining this repository please merge my PR. Thanks :)

(By the way: I changed the name of my fork to go-wex, maybe you should rename your repository too)